### PR TITLE
9.2C: Frontend CI — build on dev/PR, push on main if secrets (with decide gate)

### DIFF
--- a/.github/workflows/backend_ci.yml
+++ b/.github/workflows/backend_ci.yml
@@ -1,5 +1,5 @@
 # .github/workflows/backend_ci.yml
-name: Backend CI — test on dev/PR, build+push on main
+name: Backend CI — test on dev/PR, build+push on main (if secrets)
 
 on:
   workflow_dispatch:
@@ -23,7 +23,6 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  # Optional; only used on main for pushing images
   ACR_NAME: ${{ secrets.ACR_NAME }}
   ACR_LOGIN_SERVER: ${{ secrets.ACR_LOGIN_SERVER }}
   IMAGE_TAG: ${{ github.sha }}-${{ github.run_id }}
@@ -31,7 +30,6 @@ env:
 jobs:
   test_and_lint_backends:
     runs-on: ubuntu-latest
-
     services:
       product_db:
         image: postgres:15
@@ -45,7 +43,6 @@ jobs:
           --health-timeout 5s
           --health-retries 5
         ports: [ "5432:5432" ]
-
       order_db:
         image: postgres:15
         env:
@@ -58,24 +55,16 @@ jobs:
           --health-timeout 5s
           --health-retries 5
         ports: [ "5433:5432" ]
-
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Set up Python 3.10
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.10'
-
-      - name: Cache pip
-        uses: actions/cache@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with: { python-version: '3.10' }
+      - uses: actions/cache@v4
         with:
           path: ~/.cache/pip
           key: pip-${{ runner.os }}-py310-${{ hashFiles('backend/**/requirements.txt') }}
           restore-keys: |
             pip-${{ runner.os }}-py310-
-
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -84,7 +73,6 @@ jobs:
             pip install -r "$req"
           done
           pip install pytest httpx
-
       - name: Run product_service tests
         working-directory: backend/product_service
         env:
@@ -94,7 +82,6 @@ jobs:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
         run: pytest tests --maxfail=1 --disable-warnings -q
-
       - name: Run order_service tests
         working-directory: backend/order_service
         env:
@@ -106,37 +93,34 @@ jobs:
         run: pytest tests --maxfail=1 --disable-warnings -q
 
   build_and_push_images:
-    # Only on main branch (prod), after tests succeed
-    if: ${{ needs.test_and_lint_backends.result == 'success' && github.ref == 'refs/heads/main' }}
+    # Only on main AND only if all secrets exist
+    if: ${{ needs.test_and_lint_backends.result == 'success'
+            && github.ref == 'refs/heads/main'
+            && secrets.AZURE_CREDENTIALS != ''
+            && secrets.ACR_NAME != ''
+            && secrets.ACR_LOGIN_SERVER != '' }}
     runs-on: ubuntu-latest
     needs: test_and_lint_backends
-
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
+      - uses: actions/checkout@v4
       - name: Azure Login (OIDC)
         uses: azure/login@v2
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
-
-      - name: Login to Azure Container Registry
+      - name: Login to ACR
         run: az acr login --name "${{ env.ACR_NAME }}"
-
-      - name: Build and Push Product Service Image
+      - name: Build & Push Product Service
         run: |
           docker build -t "${{ env.ACR_LOGIN_SERVER }}/product_service:${{ env.IMAGE_TAG }}" ./backend/product_service/
-          docker tag "${{ env.ACR_LOGIN_SERVER }}/product_service:${{ env.IMAGE_TAG }}" "${{ env.ACR_LOGIN_SERVER }}/product_service:latest"
+          docker tag  "${{ env.ACR_LOGIN_SERVER }}/product_service:${{ env.IMAGE_TAG }}" "${{ env.ACR_LOGIN_SERVER }}/product_service:latest"
           docker push "${{ env.ACR_LOGIN_SERVER }}/product_service:${{ env.IMAGE_TAG }}"
           docker push "${{ env.ACR_LOGIN_SERVER }}/product_service:latest"
-
-      - name: Build and Push Order Service Image
+      - name: Build & Push Order Service
         run: |
           docker build -t "${{ env.ACR_LOGIN_SERVER }}/order_service:${{ env.IMAGE_TAG }}" ./backend/order_service/
-          docker tag "${{ env.ACR_LOGIN_SERVER }}/order_service:${{ env.IMAGE_TAG }}" "${{ env.ACR_LOGIN_SERVER }}/order_service:latest"
+          docker tag  "${{ env.ACR_LOGIN_SERVER }}/order_service:${{ env.IMAGE_TAG }}" "${{ env.ACR_LOGIN_SERVER }}/order_service:latest"
           docker push "${{ env.ACR_LOGIN_SERVER }}/order_service:${{ env.IMAGE_TAG }}"
           docker push "${{ env.ACR_LOGIN_SERVER }}/order_service:latest"
-
       - name: Azure Logout
         if: always()
         run: az logout

--- a/.github/workflows/frontend_ci.yml
+++ b/.github/workflows/frontend_ci.yml
@@ -22,13 +22,14 @@ concurrency:
   group: frontend-ci-${{ github.ref }}
   cancel-in-progress: true
 
+# Mirror secrets into env so we can safely reference them in `if:` expressions
 env:
   ACR_NAME: ${{ secrets.ACR_NAME }}
   ACR_LOGIN_SERVER: ${{ secrets.ACR_LOGIN_SERVER }}
   IMAGE_TAG: ${{ github.sha }}-${{ github.run_id }}
 
 jobs:
-  # Dev/PR: verify Docker image builds (no Azure, no push)
+  # On dev/PR: verify the image builds locally (no push, no Azure)
   build_frontend_locally:
     runs-on: ubuntu-latest
     steps:
@@ -37,13 +38,13 @@ jobs:
         run: |
           docker build -t local/frontend:${{ env.IMAGE_TAG }} ./frontend
 
-  # Main: build & push to ACR (only if secrets exist)
+  # On main: build & push only if env (mirrored secrets) are present
   build_and_push_image:
-    if: >
+    if: |
       needs.build_frontend_locally.result == 'success' &&
       github.ref == 'refs/heads/main' &&
-      env.ACR_NAME != '' &&
-      env.ACR_LOGIN_SERVER != ''
+      secrets.ACR_NAME != '' &&
+      secrets.ACR_LOGIN_SERVER != ''
     runs-on: ubuntu-latest
     needs: build_frontend_locally
     steps:
@@ -55,14 +56,14 @@ jobs:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
       - name: Login to ACR
-        run: az acr login --name "${{ env.ACR_NAME }}"
+        run: az acr login --name "${{ secrets.ACR_NAME }}"
 
       - name: Docker build & push
         run: |
-          docker build -t "${{ env.ACR_LOGIN_SERVER }}/frontend:${{ env.IMAGE_TAG }}" ./frontend
-          docker tag  "${{ env.ACR_LOGIN_SERVER }}/frontend:${{ env.IMAGE_TAG }}" "${{ env.ACR_LOGIN_SERVER }}/frontend:latest"
-          docker push "${{ env.ACR_LOGIN_SERVER }}/frontend:${{ env.IMAGE_TAG }}"
-          docker push "${{ env.ACR_LOGIN_SERVER }}/frontend:latest"
+          docker build -t "${{ secrets.ACR_LOGIN_SERVER }}/frontend:${{ github.sha }}" ./frontend
+          docker tag  "${{ secrets.ACR_LOGIN_SERVER }}/frontend:${{ github.sha }}" "${{ secrets.ACR_LOGIN_SERVER }}/frontend:latest"
+          docker push "${{ secrets.ACR_LOGIN_SERVER }}/frontend:${{ github.sha }}"
+          docker push "${{ secrets.ACR_LOGIN_SERVER }}/frontend:latest"
 
       - name: Azure Logout
         if: always()

--- a/.github/workflows/frontend_ci.yml
+++ b/.github/workflows/frontend_ci.yml
@@ -22,31 +22,46 @@ concurrency:
   group: frontend-ci-${{ github.ref }}
   cancel-in-progress: true
 
-# Mirror secrets into env so we can safely reference them in `if:` expressions
 env:
-  ACR_NAME: ${{ secrets.ACR_NAME }}
-  ACR_LOGIN_SERVER: ${{ secrets.ACR_LOGIN_SERVER }}
   IMAGE_TAG: ${{ github.sha }}-${{ github.run_id }}
 
 jobs:
-  # On dev/PR: verify the image builds locally (no push, no Azure)
+  # Always: prove the image can build (no Azure, no push)
   build_frontend_locally:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Docker build (no push)
-        run: |
-          docker build -t local/frontend:${{ env.IMAGE_TAG }} ./frontend
+        run: docker build -t local/frontend:${{ env.IMAGE_TAG }} ./frontend
 
-  # On main: build & push only if env (mirrored secrets) are present
-  build_and_push_image:
-    if: |
-      needs.build_frontend_locally.result == 'success' &&
-      github.ref == 'refs/heads/main' &&
-      secrets.ACR_NAME != '' &&
-      secrets.ACR_LOGIN_SERVER != ''
+  # Compute whether we *should* push (branch == main AND all secrets exist)
+  decide_push:
     runs-on: ubuntu-latest
     needs: build_frontend_locally
+    outputs:
+      PUSH_OK: ${{ steps.chk.outputs.push_ok }}
+    steps:
+      - id: chk
+        env:
+          BRANCH_REF: ${{ github.ref }}
+          ACR_NAME: ${{ secrets.ACR_NAME }}
+          ACR_LOGIN_SERVER: ${{ secrets.ACR_LOGIN_SERVER }}
+          AZURE_CREDENTIALS: ${{ secrets.AZURE_CREDENTIALS }}
+        run: |
+          set -euo pipefail
+          ok="false"
+          if [ "$BRANCH_REF" = "refs/heads/main" ] && \
+             [ -n "${ACR_NAME:-}" ] && [ -n "${ACR_LOGIN_SERVER:-}" ] && [ -n "${AZURE_CREDENTIALS:-}" ]; then
+            ok="true"
+          fi
+          echo "push_ok=$ok" >> "$GITHUB_OUTPUT"
+          echo "Decision: push_ok=$ok"
+
+  # Only runs when decide_push says true
+  build_and_push_image:
+    runs-on: ubuntu-latest
+    needs: [build_frontend_locally, decide_push]
+    if: ${{ needs.decide_push.outputs.PUSH_OK == 'true' }}
     steps:
       - uses: actions/checkout@v4
 
@@ -60,9 +75,9 @@ jobs:
 
       - name: Docker build & push
         run: |
-          docker build -t "${{ secrets.ACR_LOGIN_SERVER }}/frontend:${{ github.sha }}" ./frontend
-          docker tag  "${{ secrets.ACR_LOGIN_SERVER }}/frontend:${{ github.sha }}" "${{ secrets.ACR_LOGIN_SERVER }}/frontend:latest"
-          docker push "${{ secrets.ACR_LOGIN_SERVER }}/frontend:${{ github.sha }}"
+          docker build -t "${{ secrets.ACR_LOGIN_SERVER }}/frontend:${{ env.IMAGE_TAG }}" ./frontend
+          docker tag  "${{ secrets.ACR_LOGIN_SERVER }}/frontend:${{ env.IMAGE_TAG }}" "${{ secrets.ACR_LOGIN_SERVER }}/frontend:latest"
+          docker push "${{ secrets.ACR_LOGIN_SERVER }}/frontend:${{ env.IMAGE_TAG }}"
           docker push "${{ secrets.ACR_LOGIN_SERVER }}/frontend:latest"
 
       - name: Azure Logout

--- a/.github/workflows/frontend_ci.yml
+++ b/.github/workflows/frontend_ci.yml
@@ -1,51 +1,67 @@
-name: Frontend CI - Build & Push Image
+# .github/workflows/frontend_ci.yml
+name: Frontend CI — build on dev/PR, push on main (if secrets)
 
 on:
   workflow_dispatch:
   push:
+    branches: [ dev, main ]
+    paths:
+      - 'frontend/**'
+      - '.github/workflows/frontend_ci.yml'
+  pull_request:
     branches: [ main ]
     paths:
       - 'frontend/**'
-      - '.github/workflows/frontend-ci.yml'
+      - '.github/workflows/frontend_ci.yml'
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: frontend-ci-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  ACR_NAME: ${{ secrets.ACR_NAME }}
+  ACR_LOGIN_SERVER: ${{ secrets.ACR_LOGIN_SERVER }}
+  IMAGE_TAG: ${{ github.sha }}-${{ github.run_id }}
 
 jobs:
-  build_and_push_image:
+  # Dev/PR: verify Docker image builds (no Azure, no push)
+  build_frontend_locally:
     runs-on: ubuntu-latest
-
-    env:
-      # from repo secrets
-      ACR_NAME: ${{ secrets.ACR_NAME }}                 # e.g. acrweek0820618
-      ACR_LOGIN_SERVER: ${{ secrets.ACR_LOGIN_SERVER }} # e.g. acrweek0820618.azurecr.io
-
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+      - name: Docker build (no push)
+        run: |
+          docker build -t local/frontend:${{ env.IMAGE_TAG }} ./frontend
 
-      - name: Azure Login
-        uses: azure/login@v1
+  # Main: build & push to ACR (only if secrets exist)
+  build_and_push_image:
+    if: >
+      needs.build_frontend_locally.result == 'success' &&
+      github.ref == 'refs/heads/main' &&
+      env.ACR_NAME != '' &&
+      env.ACR_LOGIN_SERVER != ''
+    runs-on: ubuntu-latest
+    needs: build_frontend_locally
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Azure Login (OIDC)
+        uses: azure/login@v2
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
-      # ✅ Robust ACR login: if ACR_NAME is blank, derive it from ACR_LOGIN_SERVER
-      - name: Derive ACR name and login
+      - name: Login to ACR
+        run: az acr login --name "${{ env.ACR_NAME }}"
+
+      - name: Docker build & push
         run: |
-          ACR_LOGIN_SERVER="${{ env.ACR_LOGIN_SERVER }}"
-          if [ -z "$ACR_LOGIN_SERVER" ]; then
-            echo "Secret ACR_LOGIN_SERVER is not set."; exit 1
-          fi
-
-          ACR_NAME="${{ env.ACR_NAME }}"
-          if [ -z "$ACR_NAME" ]; then
-            ACR_NAME="$(echo "$ACR_LOGIN_SERVER" | cut -d. -f1)"
-          fi
-
-          echo "Using ACR_NAME: $ACR_NAME"
-          az acr login --name "$ACR_NAME"
-
-      # Adjust path if your Dockerfile is not in ./frontend
-      - name: Docker Build & Push
-        run: |
-          docker build -t "${{ env.ACR_LOGIN_SERVER }}/frontend:latest" ./frontend
+          docker build -t "${{ env.ACR_LOGIN_SERVER }}/frontend:${{ env.IMAGE_TAG }}" ./frontend
+          docker tag  "${{ env.ACR_LOGIN_SERVER }}/frontend:${{ env.IMAGE_TAG }}" "${{ env.ACR_LOGIN_SERVER }}/frontend:latest"
+          docker push "${{ env.ACR_LOGIN_SERVER }}/frontend:${{ env.IMAGE_TAG }}"
           docker push "${{ env.ACR_LOGIN_SERVER }}/frontend:latest"
 
       - name: Azure Logout


### PR DESCRIPTION
- Added conditional logic to only push frontend images to ACR on main.
- Verified build runs successfully on dev and PR branches without pushing.
- Secrets check and decide_push gate implemented for safe deployments.
